### PR TITLE
Adjusting touchable style for defined metrics

### DIFF
--- a/components/History.js
+++ b/components/History.js
@@ -34,6 +34,7 @@ class History extends Component {
             </Text>
           </View>
         : <TouchableOpacity
+            style={styles.item}
             onPress={() => console.log('Pressed!')}
           >
             <MetricCard date={formattedDate} metrics={metrics} />


### PR DESCRIPTION
After watching the video I took a look at the `History` component and saw that it was missing to add the` item` style in `TouchableOpacity` when the metrics is defined.